### PR TITLE
fix: handle multiple names on same route

### DIFF
--- a/packages/document-routes/Dockerfile
+++ b/packages/document-routes/Dockerfile
@@ -3,10 +3,21 @@ FROM node:12.16.1-alpine
 LABEL "name"="Check Routes"
 LABEL "maintainer"="Hive HR <engineering@hive.hr>"
 LABEL "version"="1.0.0"
+
 LABEL "com.github.actions.inputs.pattern.description"="Glob pattern to search for route files (relative to github workspace)"
 LABEL "com.github.actions.inputs.pattern.required"="true"
+
 LABEL "com.github.actions.inputs.out_path.description"="Location to store the generated files (relative to github workspace)"
 LABEL "com.github.actions.inputs.out_path.required"="true"
+
+LABEL "com.github.actions.inputs.or_statement_regex.description"="Regex string to match or statement on a permission"
+LABEL "com.github.actions.inputs.outor_statement_regex_path.required"="false"
+
+LABEL "com.github.actions.inputs.controller_name_regex.description"="Regex string to match controller names"
+LABEL "com.github.actions.inputs.controller_name_regex.required"="false"
+
+LABEL "com.github.actions.inputs.require_scopes_regex.description"="Regex string to match the require_scopes string"
+LABEL "com.github.actions.inputs.require_scopes_regex.required"="false"
 
 WORKDIR /app
 COPY . .

--- a/packages/document-routes/babel-plugin-express-routes/test/__snapshots__/permissions.test.ts.snap
+++ b/packages/document-routes/babel-plugin-express-routes/test/__snapshots__/permissions.test.ts.snap
@@ -4,10 +4,11 @@ exports[`Permissions require scope with single rag and two ors with single arg 1
 "{
   \\"serviceName\\": \\"service\\",
   \\"controllerName\\": \\"require_scope_with_single_rag_and_two_ors_with_single_arg\\",
-  \\"routes\\": {
-    \\"/route\\": {
-      \\"permissions\\": \\"(over here 2) || (here) || (permission)\\",
-      \\"method\\": \\"get\\"
+  \\"methods\\": {
+    \\"get\\": {
+      \\"/route\\": {
+        \\"permissions\\": \\"(over here 2) || (here) || (permission)\\"
+      }
     }
   }
 }"
@@ -17,10 +18,11 @@ exports[`Permissions requireScope with array arg 1`] = `
 "{
   \\"serviceName\\": \\"service\\",
   \\"controllerName\\": \\"require_scope_with_array_arg\\",
-  \\"routes\\": {
-    \\"/route\\": {
-      \\"permissions\\": \\"(permission && permission2)\\",
-      \\"method\\": \\"get\\"
+  \\"methods\\": {
+    \\"get\\": {
+      \\"/route\\": {
+        \\"permissions\\": \\"(permission && permission2)\\"
+      }
     }
   }
 }"
@@ -30,10 +32,11 @@ exports[`Permissions requireScope with array arg and 'or' with array arg 1`] = `
 "{
   \\"serviceName\\": \\"service\\",
   \\"controllerName\\": \\"require_scope_with_array_arg_and_or_with_array_arg\\",
-  \\"routes\\": {
-    \\"/route\\": {
-      \\"permissions\\": \\"(here && here2) || (permission && permissions1)\\",
-      \\"method\\": \\"get\\"
+  \\"methods\\": {
+    \\"get\\": {
+      \\"/route\\": {
+        \\"permissions\\": \\"(here && here2) || (permission && permissions1)\\"
+      }
     }
   }
 }"
@@ -43,10 +46,11 @@ exports[`Permissions requireScope with single arg 1`] = `
 "{
   \\"serviceName\\": \\"service\\",
   \\"controllerName\\": \\"require_scope_with_single_arg\\",
-  \\"routes\\": {
-    \\"/route\\": {
-      \\"permissions\\": \\"(permission)\\",
-      \\"method\\": \\"get\\"
+  \\"methods\\": {
+    \\"get\\": {
+      \\"/route\\": {
+        \\"permissions\\": \\"(permission)\\"
+      }
     }
   }
 }"
@@ -56,10 +60,11 @@ exports[`Permissions requireScope with single arg and 'or' with array arg 1`] = 
 "{
   \\"serviceName\\": \\"service\\",
   \\"controllerName\\": \\"require_scope_with_single_arg_and_or_with_array_arg\\",
-  \\"routes\\": {
-    \\"/route\\": {
-      \\"permissions\\": \\"(here && here2) || (permission)\\",
-      \\"method\\": \\"get\\"
+  \\"methods\\": {
+    \\"get\\": {
+      \\"/route\\": {
+        \\"permissions\\": \\"(here && here2) || (permission)\\"
+      }
     }
   }
 }"
@@ -69,10 +74,11 @@ exports[`Permissions requireScope with single arg and 'or' with single arg 1`] =
 "{
   \\"serviceName\\": \\"service\\",
   \\"controllerName\\": \\"require_scope_with_single_arg_and_or_with_single_arg\\",
-  \\"routes\\": {
-    \\"/route\\": {
-      \\"permissions\\": \\"(here) || (permission)\\",
-      \\"method\\": \\"get\\"
+  \\"methods\\": {
+    \\"get\\": {
+      \\"/route\\": {
+        \\"permissions\\": \\"(here) || (permission)\\"
+      }
     }
   }
 }"
@@ -82,10 +88,11 @@ exports[`Permissions route with no permissions required 1`] = `
 "{
   \\"serviceName\\": \\"service\\",
   \\"controllerName\\": \\"no_permissions_required\\",
-  \\"routes\\": {
-    \\"/route\\": {
-      \\"permissions\\": \\"(No permissions required)\\",
-      \\"method\\": \\"get\\"
+  \\"methods\\": {
+    \\"get\\": {
+      \\"/route\\": {
+        \\"permissions\\": \\"(No permissions required)\\"
+      }
     }
   }
 }"
@@ -95,10 +102,51 @@ exports[`Permissions test all request methods 1`] = `
 "{
   \\"serviceName\\": \\"service\\",
   \\"controllerName\\": \\"test_all_request_methods\\",
-  \\"routes\\": {
-    \\"/route\\": {
-      \\"permissions\\": \\"(permission)\\",
-      \\"method\\": \\"get\\"
+  \\"methods\\": {
+    \\"get\\": {
+      \\"/route\\": {
+        \\"permissions\\": \\"(permission)\\"
+      }
+    },
+    \\"head\\": {
+      \\"/route\\": {
+        \\"permissions\\": \\"(permission)\\"
+      }
+    },
+    \\"post\\": {
+      \\"/route\\": {
+        \\"permissions\\": \\"(permission)\\"
+      }
+    },
+    \\"put\\": {
+      \\"/route\\": {
+        \\"permissions\\": \\"(permission)\\"
+      }
+    },
+    \\"delete\\": {
+      \\"/route\\": {
+        \\"permissions\\": \\"(permission)\\"
+      }
+    },
+    \\"connect\\": {
+      \\"/route\\": {
+        \\"permissions\\": \\"(permission)\\"
+      }
+    },
+    \\"options\\": {
+      \\"/route\\": {
+        \\"permissions\\": \\"(permission)\\"
+      }
+    },
+    \\"trace\\": {
+      \\"/route\\": {
+        \\"permissions\\": \\"(permission)\\"
+      }
+    },
+    \\"patch\\": {
+      \\"/route\\": {
+        \\"permissions\\": \\"(permission)\\"
+      }
     }
   }
 }"

--- a/packages/document-routes/babel-plugin-express-routes/test/fixtures/packages/service/src/routes/test_all_request_methods.ts
+++ b/packages/document-routes/babel-plugin-express-routes/test/fixtures/packages/service/src/routes/test_all_request_methods.ts
@@ -13,3 +13,11 @@ const router = {
 };
 
 router.get("/route", requireScopes("permission"));
+router.head("/route", requireScopes("permission"));
+router.post("/route", requireScopes("permission"));
+router.put("/route", requireScopes("permission"));
+router.delete("/route", requireScopes("permission"));
+router.connect("/route", requireScopes("permission"));
+router.options("/route", requireScopes("permission"));
+router.trace("/route", requireScopes("permission"));
+router.patch("/route", requireScopes("permission"));

--- a/packages/document-routes/babel.config.js
+++ b/packages/document-routes/babel.config.js
@@ -8,7 +8,14 @@ module.exports = function(api) {
             [
                 join(__dirname, "./babel-plugin-express-routes"),
                 {
-                    outPath: `${process.env.GITHUB_WORKSPACE || "."}/${process.env.INPUT_OUT_PATH}`,
+                    outPath: `${process.env.GITHUB_WORKSPACE || "."}/${process
+                        .env.INPUT_OUT_PATH || ""}`,
+                    orStatementRegexString: `${process.env
+                        .INPUT_OR_STATEMENT_REGEX || "or"} `,
+                    controllerNameRegexString: `${process.env
+                        .INPUT_CONTROLLER_NAME_REGEX || "router"}`,
+                    requireScopesRegexString: `${process.env
+                        .INPUT_REQUIRE_SCOPES_REGEX || "requireScopes"}`,
                     maxDepth: 10
                 }
             ]

--- a/packages/document-routes/src/generateMarkdown.ts
+++ b/packages/document-routes/src/generateMarkdown.ts
@@ -29,7 +29,7 @@ enum RequestMethod {
 interface SimpleController {
     serviceName: string;
     controllerName: string;
-    routes: object;
+    methods: object;
 }
 
 interface Route {
@@ -40,18 +40,20 @@ interface Route {
 interface Controller {
     serviceName: string;
     controllerName: string;
-    routes: Map<string, Route>;
+    methods: Map<RequestMethod, Map<string, Route>>;
 }
 
 const capitalize = (content: string): string =>
     content.charAt(0).toUpperCase() + content.slice(1);
 
 const convertController = (controller: SimpleController): Controller => {
-    const routesMap = new Map<string, any>();
-    Array.from(Object.entries(controller.routes)).forEach(([key, value]) =>
-        routesMap.set(key, value)
-    );
-    return { ...controller, routes: routesMap };
+    const methodsMap = new Map<RequestMethod, Map<string, Route>>();
+    Array.from(Object.entries(controller.methods)).forEach(([method, routes]) => {
+        const routesMap = new Map<string, Route>();
+        Array.from(Object.entries(routes)).forEach(([route, permissions]) => routesMap.set(route, permissions as Route))
+        methodsMap.set(method as RequestMethod, routesMap)
+    });
+    return { ...controller, methods: methodsMap };
 };
 
 export const generateMarkdown = (dir: string): string => {

--- a/packages/document-routes/src/templates/markdown.handlebars
+++ b/packages/document-routes/src/templates/markdown.handlebars
@@ -12,8 +12,10 @@
 * /{{controllerName}}
     | Route Name | Method | Required Permissions |
     | ---------- | ------ | -------------------- |
-    {{#eachInMap routes}}
-    | {{key}} | {{value.method}} | {{value.permissions}} |
+    {{#eachInMap methods}}
+    {{#eachInMap value}}
+    | {{key}} | {{../key}} | {{value.permissions}} |
+    {{/eachInMap}}
     {{/eachInMap}}
 {{/each}}
 


### PR DESCRIPTION
Convert the output structure of the document routes action to format based on method first.
```
{
    serviceName: string;
    controllerName: string;
    methods: Map<RequestMethod, Map<string, Route>>;
}
```

Added inputs for configuring the plugin options:
* or_statement_regex : Regex string to match or statement on a permission
* controller_name_regex: Regex string to match controller names
* require_scopes_regex: Regex string to match the require_scopes string
